### PR TITLE
Removed -Wno-format from CFLAGS.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,4 +1,4 @@
-CFLAGS += -Wall -Wno-switch -Wno-parentheses -Wno-format -Wno-unused-variable -Wno-unused-but-set-variable -Wextra -Wno-unused-parameter -Wno-sign-compare -Wmissing-prototypes
+CFLAGS += -Wall -Wno-switch -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wextra -Wno-unused-parameter -Wno-sign-compare -Wmissing-prototypes
 
 SOURCES_C := $(CORE_DIR)/access.c $(CORE_DIR)/boot.c $(CORE_DIR)/branch.c \
 	$(CORE_DIR)/covox.c $(CORE_DIR)/double.c $(CORE_DIR)/ea.c \


### PR DESCRIPTION
Hi,

I'm integrating this core with Yocto, I have problem with compilation:
cc1: error: '-Wformat-security' ignored without '-Wformat' [-Werror=format-security]

Yocto is passing -Wformat-security as important flag by toolchain and it's not compatible with -Wno-format. Please consider removing this flag. I was able to compile project without -Wno-format (gcc 9.2, amd64, linux).
